### PR TITLE
Improve memories page with scroll animations

### DIFF
--- a/src/components/BannerMemories.tsx
+++ b/src/components/BannerMemories.tsx
@@ -2,7 +2,7 @@
 import { FC, useRef, useLayoutEffect } from 'react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
-import heroImg from '../assets/banner-recuerdos.jpg' // tu imagen de banner
+import heroImg from '../assets/banner-recuerdos.jpg'
 import { useTranslation } from 'react-i18next'
 
 gsap.registerPlugin(ScrollTrigger)
@@ -13,10 +13,14 @@ const BannerMemories: FC = () => {
   const titleRef = useRef<HTMLHeadingElement>(null)
   const subtitleRef = useRef<HTMLParagraphElement>(null)
 
+  const title = t('memories.banner.title', 'TODO LO MEMORABLE COMIENZA CON UN...')
+  const subtitle = t('memories.banner.subtitle', '¿QUÉ HACES ESTE SÁBADO?')
+  const titleWords = title.split(' ')
+  const subtitleWords = subtitle.split(' ')
+
   useLayoutEffect(() => {
     if (!bannerRef.current) return
 
-    // Pin del banner
     ScrollTrigger.create({
       trigger: bannerRef.current,
       start: 'top top',
@@ -25,26 +29,25 @@ const BannerMemories: FC = () => {
       pinSpacing: false
     })
 
-    // Animación entrada del título
-    gsap.from(titleRef.current, {
-      scrollTrigger: {
-        trigger: bannerRef.current,
-        start: 'top top+=50',
-        end: 'bottom top',
-        scrub: true,
-      },
-      y: 100,
-      opacity: 0,
-      ease: 'power2.out'
-    })
+    const ctx = gsap.context(() => {
+      const words = bannerRef.current!.querySelectorAll('.banner-word')
 
-    // Subtítulo con loop de “latido”
-    const tl = gsap.timeline({ repeat: -1, yoyo: true, delay: 1 })
-    tl.to(subtitleRef.current, {
-      scale: 1.1,
-      duration: 0.6,
-      ease: 'sine.inOut'
-    })
+      gsap.timeline({
+        scrollTrigger: {
+          trigger: bannerRef.current,
+          start: 'top top',
+          end: 'bottom top',
+          scrub: true
+        }
+      }).from(words, {
+        opacity: 0,
+        yPercent: 100,
+        stagger: 0.05,
+        ease: 'power2.out'
+      })
+    }, bannerRef)
+
+    return () => ctx.revert()
   }, [])
 
   return (
@@ -65,13 +68,21 @@ const BannerMemories: FC = () => {
           ref={titleRef}
           className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-extrabold text-white uppercase leading-tight"
         >
-          {t('memories.banner.title', 'TODO LO MEMORABLE COMIENZA CON UN...')}
+          {titleWords.map((w, i) => (
+            <span key={i} className="banner-word inline-block mr-2">
+              {w}
+            </span>
+          ))}
         </h1>
         <p
           ref={subtitleRef}
           className="mt-6 text-2xl sm:text-3xl font-semibold text-yellow-400 uppercase"
         >
-          {t('memories.banner.subtitle', '¿QUÉ HACES ESTE SÁBADO?')}
+          {subtitleWords.map((w, i) => (
+            <span key={i} className="banner-word inline-block mr-1">
+              {w}
+            </span>
+          ))}
         </p>
       </div>
     </section>

--- a/src/components/MemoriesGallery.tsx
+++ b/src/components/MemoriesGallery.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import CircularGallery from './Stack/CircularGallery/CircularGallery'
+
+const MemoriesGallery: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <section className="py-24 bg-black text-white flex flex-col items-center">
+      <h2 className="mb-8 text-3xl sm:text-4xl font-bold text-center">
+        {t('memories.gallery.heading', 'LOS RECUERDOS LOS CREAMOS JUNTOS/AS')}
+      </h2>
+      <div className="w-full h-[60vh] max-w-5xl">
+        <CircularGallery />
+      </div>
+    </section>
+  )
+}
+
+export default MemoriesGallery

--- a/src/components/MemoriesTimeline.tsx
+++ b/src/components/MemoriesTimeline.tsx
@@ -25,50 +25,41 @@ const MemoriesTimeline: FC = () => {
   useLayoutEffect(() => {
     if (!containerRef.current) return
 
-    // Por cada .hito-item configuramos un ScrollTrigger individual
-    gsap.utils.toArray<HTMLDivElement>('.hito-item').forEach((el, i) => {
-      gsap.from(el, {
-        scrollTrigger: {
-          trigger: el,
-          start: 'top 80%',
-          end: 'bottom 60%',
-          scrub: false,
-          // markers: true,
-        },
-        x: i % 2 === 0 ? -200 : 200,
-        opacity: 0,
-        duration: 0.8,
-        ease: 'power2.out'
-      })
+    const sections = gsap.utils.toArray<HTMLDivElement>('.hito-item')
+
+    gsap.to(sections, {
+      xPercent: -100 * (sections.length - 1),
+      ease: 'none',
+      scrollTrigger: {
+        trigger: containerRef.current,
+        pin: true,
+        scrub: 1,
+        end: () => `+=${containerRef.current!.offsetWidth * sections.length}`
+      }
     })
   }, [])
 
   return (
-    <section className="py-24 bg-gray-100" ref={containerRef}>
-      <div className="mx-auto max-w-5xl px-4 space-y-16">
-        {HITOS.map((hito, i) => {
+    <section ref={containerRef} className="bg-gray-100 h-screen overflow-hidden">
+      <div className="flex h-full" style={{ width: `${HITOS.length * 100}vw` }}>
+        {HITOS.map(hito => {
           const data = t(`memories.timeline.${hito.key}`, { returnObjects: true }) as {
             year: string
             title: string
             desc: string
           }
-
           return (
-            <div
-              key={hito.key}
-              className={`hito-item flex flex-col md:flex-row items-center gap-8 ${
-                i % 2 ? 'md:flex-row-reverse' : ''
-              }`}
-            >
+            <div key={hito.key} className="hito-item w-screen flex-shrink-0 flex flex-col items-center justify-center p-8 space-y-4">
               <img
                 src={hito.img}
                 alt={data.title}
-                className="w-full md:w-1/2 h-60 object-cover rounded-lg shadow-lg"
+                loading="lazy"
+                className="w-full h-60 object-cover rounded-lg shadow-lg"
               />
-              <div className="md:w-1/2 text-center md:text-left">
+              <div className="text-center">
                 <span className="text-primary font-bold text-lg">{data.year}</span>
                 <h3 className="mt-2 text-2xl font-semibold text-andesnavy">{data.title}</h3>
-                <p className="mt-2 text-gray-700">{data.desc}</p>
+                <p className="mt-2 text-gray-700 max-w-md">{data.desc}</p>
               </div>
             </div>
           )

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -174,34 +174,9 @@
         "title": "Growing alliances",
         "desc": "Joined forces with Cuenca Bike Tours, Prefectura del Azuay, Bio Parque Amaru..."
       }
-    }
-  },
-  "memories": {
-    "banner": {
-      "title": "TODO LO MEMORABLE COMIENZA CON UN…",
-      "subtitle": "¿Qué haces este sábado?"
     },
-    "timeline": {
-      "2019": {
-        "year": "2019",
-        "title": "Nuestro primer pedal",
-        "desc": "Julio creció en bici y en 2019 lanzó Tomebambike para promover el ciclismo urbano..."
-      },
-      "2024": {
-        "year": "2024",
-        "title": "Encuentro con Adrián",
-        "desc": "A través de Safe And Sound Cities conocimos a Adrián y organizamos nuestro primer ciclopaseo..."
-      },
-      "uda": {
-        "year": "2025",
-        "title": "Piloto UDA sobre Ruedas",
-        "desc": "Aliados con la Universidad del Azuay para talleres de mecánica, seguridad vial..."
-      },
-      "partners": {
-        "year": "2025",
-        "title": "Alianzas crecientes",
-        "desc": "Junto a Cuenca Bike Tours, Prefectura del Azuay, BioParque Amaru..."
-      }
+    "gallery": {
+      "heading": "We create memories together"
     }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -173,6 +173,9 @@
         "title": "Alianzas crecientes",
         "desc": "Junto a Cuenca Bike Tours, Prefectura del Azuay, BioParque Amaru..."
       }
+    },
+    "gallery": {
+      "heading": "Los recuerdos los creamos juntos/as"
     }
   }
 }

--- a/src/pages/Memories.tsx
+++ b/src/pages/Memories.tsx
@@ -1,6 +1,7 @@
 // src/pages/RecuerdosPage.tsx
 import BannerMemories from '../components/BannerMemories'
 import MemoriesTimeline from '../components/MemoriesTimeline'
+import MemoriesGallery from '../components/MemoriesGallery'
 import { FC } from 'react'
 
 
@@ -8,6 +9,7 @@ export const MemoriesPage: FC = () => (
   <>
     <BannerMemories />
     <MemoriesTimeline/>
+    <MemoriesGallery />
   </>
 )
 export default MemoriesPage


### PR DESCRIPTION
## Summary
- animate BannerMemories per-word using GSAP ScrollTrigger
- make MemoriesTimeline scroll horizontally
- show CircularGallery with heading after the timeline
- add i18n translations for new gallery text
- load timeline images lazily

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687069ab578083308f376aa6a604249c