### PR TITLE
Fix build failure by removing unused import

### DIFF
--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { motion } from 'framer-motion'
 
 // ① Importa tus imágenes como módulos
 import hero1 from '../assets/hero1.jpg'


### PR DESCRIPTION
## Summary
- remove unused framer-motion import in `HeroCarousel`

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68706d0f7fcc8330b3f597aa0f917df0