### PR TITLE
Improve memories interactions

### DIFF
--- a/src/components/BannerMemories.tsx
+++ b/src/components/BannerMemories.tsx
@@ -14,36 +14,53 @@ const BannerMemories: FC = () => {
   const subtitleRef = useRef<HTMLParagraphElement>(null)
 
   useLayoutEffect(() => {
-    if (!bannerRef.current) return
+    if (!bannerRef.current || !titleRef.current || !subtitleRef.current) return
 
     // Pin del banner
     ScrollTrigger.create({
       trigger: bannerRef.current,
       start: 'top top',
-      end: '+=200%',
+      end: '+=150%',
       pin: true,
       pinSpacing: false
     })
 
-    // Animación entrada del título
-    gsap.from(titleRef.current, {
+    // Animación secuencial de palabras del título
+    gsap.from(titleRef.current.children, {
       scrollTrigger: {
         trigger: bannerRef.current,
-        start: 'top top+=50',
-        end: 'bottom top',
-        scrub: true,
+        start: 'top top',
+        end: '+=50%',
+        scrub: true
       },
-      y: 100,
+      y: 80,
+      opacity: 0,
+      stagger: 0.15,
+      ease: 'power2.out'
+    })
+
+    // Aparición del subtítulo
+    gsap.from(subtitleRef.current, {
+      scrollTrigger: {
+        trigger: bannerRef.current,
+        start: 'top+=40% top',
+        end: 'bottom top',
+        scrub: true
+      },
+      y: 60,
       opacity: 0,
       ease: 'power2.out'
     })
 
-    // Subtítulo con loop de “latido”
-    const tl = gsap.timeline({ repeat: -1, yoyo: true, delay: 1 })
-    tl.to(subtitleRef.current, {
-      scale: 1.1,
-      duration: 0.6,
-      ease: 'sine.inOut'
+    // Desvanecer banner al salir
+    gsap.to(bannerRef.current, {
+      scrollTrigger: {
+        trigger: bannerRef.current,
+        start: 'bottom top',
+        end: 'bottom top+=25%',
+        scrub: true
+      },
+      opacity: 0
     })
   }, [])
 
@@ -65,7 +82,13 @@ const BannerMemories: FC = () => {
           ref={titleRef}
           className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-extrabold text-white uppercase leading-tight"
         >
-          {t('memories.banner.title', 'TODO LO MEMORABLE COMIENZA CON UN...')}
+          {t('memories.banner.title', 'TODO LO MEMORABLE COMIENZA CON UN...')
+            .split(' ')
+            .map((w, i) => (
+              <span key={i} className="inline-block mr-2">
+                {w}
+              </span>
+            ))}
         </h1>
         <p
           ref={subtitleRef}

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { motion } from 'framer-motion'
 
 // ① Importa tus imágenes como módulos
 import hero1 from '../assets/hero1.jpg'

--- a/src/components/MemoriesGallery.tsx
+++ b/src/components/MemoriesGallery.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import CircularGallery from './Stack/CircularGallery/CircularGallery'
+import slide1 from '../assets/slide1.png'
+import slide2 from '../assets/slide2.png'
+import slide3 from '../assets/slide3.png'
+import slide4 from '../assets/slide4.png'
+
+const items = [
+  { image: slide1, text: '1' },
+  { image: slide2, text: '2' },
+  { image: slide3, text: '3' },
+  { image: slide4, text: '4' }
+]
+
+const MemoriesGallery: FC = () => {
+  const { t } = useTranslation()
+  return (
+    <section className="py-20 bg-white flex flex-col items-center gap-8">
+      <h2 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-andesnavy uppercase text-center">
+        {t('memories.gallery.title')}
+      </h2>
+      <div className="w-full h-[70vh] max-w-5xl">
+        <CircularGallery items={items} />
+      </div>
+    </section>
+  )
+}
+
+export default MemoriesGallery

--- a/src/components/MemoriesTimeline.tsx
+++ b/src/components/MemoriesTimeline.tsx
@@ -25,28 +25,41 @@ const MemoriesTimeline: FC = () => {
   useLayoutEffect(() => {
     if (!containerRef.current) return
 
-    // Por cada .hito-item configuramos un ScrollTrigger individual
-    gsap.utils.toArray<HTMLDivElement>('.hito-item').forEach((el, i) => {
+    const sections = gsap.utils.toArray<HTMLDivElement>('.hito-item')
+
+    gsap.to(sections, {
+      xPercent: -100 * (sections.length - 1),
+      ease: 'none',
+      scrollTrigger: {
+        trigger: containerRef.current,
+        start: 'top top',
+        end: () => `+=${containerRef.current!.offsetWidth * sections.length}`,
+        scrub: true,
+        pin: true,
+        anticipatePin: 1,
+        id: 'timeline'
+      }
+    })
+
+    sections.forEach((el) => {
       gsap.from(el, {
+        opacity: 0,
+        y: 50,
         scrollTrigger: {
           trigger: el,
-          start: 'top 80%',
-          end: 'bottom 60%',
-          scrub: false,
-          // markers: true,
-        },
-        x: i % 2 === 0 ? -200 : 200,
-        opacity: 0,
-        duration: 0.8,
-        ease: 'power2.out'
+          containerAnimation: ScrollTrigger.getById('timeline')?.animation as gsap.core.Animation,
+          start: 'left center',
+          end: 'right center',
+          scrub: true
+        }
       })
     })
   }, [])
 
   return (
-    <section className="py-24 bg-gray-100" ref={containerRef}>
-      <div className="mx-auto max-w-5xl px-4 space-y-16">
-        {HITOS.map((hito, i) => {
+    <section ref={containerRef} className="timeline-section h-screen bg-gray-100 overflow-hidden">
+      <div className="timeline-wrapper flex h-full">
+        {HITOS.map((hito) => {
           const data = t(`memories.timeline.${hito.key}`, { returnObjects: true }) as {
             year: string
             title: string
@@ -56,16 +69,14 @@ const MemoriesTimeline: FC = () => {
           return (
             <div
               key={hito.key}
-              className={`hito-item flex flex-col md:flex-row items-center gap-8 ${
-                i % 2 ? 'md:flex-row-reverse' : ''
-              }`}
+              className="hito-item w-[70vw] flex-shrink-0 flex flex-col items-center justify-center gap-6 px-8"
             >
               <img
                 src={hito.img}
                 alt={data.title}
-                className="w-full md:w-1/2 h-60 object-cover rounded-lg shadow-lg"
+                className="w-full h-60 object-cover rounded-lg shadow-lg"
               />
-              <div className="md:w-1/2 text-center md:text-left">
+              <div className="text-center">
                 <span className="text-primary font-bold text-lg">{data.year}</span>
                 <h3 className="mt-2 text-2xl font-semibold text-andesnavy">{data.title}</h3>
                 <p className="mt-2 text-gray-700">{data.desc}</p>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -174,6 +174,9 @@
         "title": "Growing alliances",
         "desc": "Joined forces with Cuenca Bike Tours, Prefectura del Azuay, Bio Parque Amaru..."
       }
+    },
+    "gallery": {
+      "title": "Together we create the best memories"
     }
   },
   "memories": {
@@ -202,6 +205,9 @@
         "title": "Alianzas crecientes",
         "desc": "Junto a Cuenca Bike Tours, Prefectura del Azuay, BioParque Amaru..."
       }
+    },
+    "gallery": {
+      "title": "Together we create the best memories"
     }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -173,6 +173,9 @@
         "title": "Alianzas crecientes",
         "desc": "Junto a Cuenca Bike Tours, Prefectura del Azuay, BioParque Amaru..."
       }
+    },
+    "gallery": {
+      "title": "Juntos creamos los mejores recuerdos"
     }
   }
 }

--- a/src/pages/Memories.tsx
+++ b/src/pages/Memories.tsx
@@ -1,13 +1,15 @@
 // src/pages/RecuerdosPage.tsx
 import BannerMemories from '../components/BannerMemories'
 import MemoriesTimeline from '../components/MemoriesTimeline'
+import MemoriesGallery from '../components/MemoriesGallery'
 import { FC } from 'react'
 
 
 export const MemoriesPage: FC = () => (
   <>
     <BannerMemories />
-    <MemoriesTimeline/>
+    <MemoriesTimeline />
+    <MemoriesGallery />
   </>
 )
 export default MemoriesPage


### PR DESCRIPTION
## Summary
- add Gallery section with large circular gallery
- animate banner words and subtitle with ScrollTrigger
- implement horizontal timeline using GSAP
- include gallery in memories page
- fix unused import in HeroCarousel
- update i18n strings for gallery text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68706f4823f883308be2f4239c431338